### PR TITLE
Fix `local://` URIs in --files and --jars

### DIFF
--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
@@ -78,7 +78,7 @@ private[spark] object DriverTask extends SparkNomadTaskType("driver", "driver", 
       .map(_.split(",").filter(_.nonEmpty))
       .filter(_.nonEmpty)
       .foreach { files =>
-        conf.set("spark.files", files.map(asFileIn(jobConf, task)).mkString(","))
+        conf.set("spark.files", files.map(asFileIn(jobConf, task)).map(f => f.stripPrefix("local://")).mkString(","))
       }
 
     val driverConf: Seq[(String, String)] = {

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/DriverTask.scala
@@ -78,7 +78,7 @@ private[spark] object DriverTask extends SparkNomadTaskType("driver", "driver", 
       .map(_.split(",").filter(_.nonEmpty))
       .filter(_.nonEmpty)
       .foreach { files =>
-        conf.set("spark.files", files.map(asFileIn(jobConf, task)).map(f => f.stripPrefix("local://")).mkString(","))
+        conf.set("spark.files", files.map(asFileIn(jobConf, task)).mkString(","))
       }
 
     val driverConf: Seq[(String, String)] = {

--- a/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/SparkNomadTaskType.scala
+++ b/resource-managers/nomad/src/main/scala/org/apache/spark/scheduler/cluster/nomad/SparkNomadTaskType.scala
@@ -191,7 +191,10 @@ private[spark] abstract class SparkNomadTaskType(
   protected def asFileIn(jobConf: SparkNomadJob.CommonConf, task: Task)(url: String): String = {
     val (file, artifact) = asFileAndArtifact(jobConf, new URI(url), false)
     artifact.foreach(task.addArtifacts(_))
-    file.toString
+    file.getScheme match {
+      case "local" => file.getPath
+      case _ => file.toString
+    }
   }
 
   protected def jvmMemory(conf: SparkConf, task: Task): String = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change fixes the problem where referencing local files in the `--files` or `--jars` argument of the `spark-submit` command causes the Nomad job to fail to start.

## How was this patch tested?

Manually tested by adding a `--files` or `--jar` argument to sample `spark-submit` command. The file must be in a [`chroot` directory](https://www.nomadproject.io/docs/drivers/exec.html#chroot) for the allocation to be able to read it.